### PR TITLE
Fix installation issue on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,13 @@ def no_cythonize(extensions, **_ignore):
 
 COMPILE_ARGS = [
     "-std=c++11",
-    "-Wno-register",
-    "-Wno-unused-function",
-    "-Wno-unused-local-typedefs",
     "-funsigned-char",
 ]
+if os.name != "nt":
+    COMPILE_ARGS.append("-Wno-register")
+    COMPILE_ARGS.append("-Wno-unused-function")
+    COMPILE_ARGS.append("-Wno-unused-local-typedefs")
+
 if platform.startswith("darwin"):
     COMPILE_ARGS.append("-stdlib=libc++")
     COMPILE_ARGS.append("-mmacosx-version-min=10.7")


### PR DESCRIPTION
I got an error like this when installing it on Windows:

```
Installing collected packages: cylimiter
    Running setup.py install for cylimiter ... error
    ERROR: Command errored out with exit status 1:
     command: 'C:\Users\iver5\Anaconda3\envs\audiomentations\python.exe' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\iver5\\AppData\\Local\\Temp\\pip-install-_wt0rjvx\\cylimiter_5dc84be7ac8d4b80ae4454d60232d241\\setup.py'"'"'; __file__='"'"'C:\\Users\\iver5\\AppData\\Local\\Temp\\pip-install-_wt0rjvx\\cylimiter_5dc84be7ac8d4b80ae4454d60232d241\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record 'C:\Users\iver5\AppData\Local\Temp\pip-record-72ccq_mp\install-record.txt' --single-version-externally-managed --compile --install-headers 'C:\Users\iver5\Anaconda3\envs\audiomentations\Include\cylimiter'
         cwd: C:\Users\iver5\AppData\Local\Temp\pip-install-_wt0rjvx\cylimiter_5dc84be7ac8d4b80ae4454d60232d241\
    Complete output (15 lines):
    running install
    running build
    running build_py
    creating build
    creating build\lib.win-amd64-3.7
    creating build\lib.win-amd64-3.7\extensions
    copying extensions\__init__.py -> build\lib.win-amd64-3.7\extensions
    running build_ext
    building 'cylimiter' extension
    creating build\temp.win-amd64-3.7
    creating build\temp.win-amd64-3.7\Release
    creating build\temp.win-amd64-3.7\Release\extensions
    C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.28.29333\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -IC:\Users\iver5\AppData\Local\Temp\pip-install-_wt0rjvx\cylimiter_5dc84be7ac8d4b80ae4454d60232d241/extensions -IC:\Users\iver5\Anaconda3\envs\audiomentations\include -IC:\Users\iver5\Anaconda3\envs\audiomentations\include "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.28.29333\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\cppwinrt" /EHsc /Tpextensions/cylimiter.cpp /Fobuild\temp.win-amd64-3.7\Release\extensions/cylimiter.obj -std=c++11 -Wno-register -Wno-unused-function -Wno-unused-local-typedefs -funsigned-char
    cl : Command line error D8021 : invalid numeric argument '/Wno-register'
    error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Tools\\MSVC\\14.28.29333\\bin\\HostX86\\x64\\cl.exe' failed with exit status 2
```

It installs fine on Windows without these compile args 👍 