### PR TITLE
auto-vectorization with clang and gcc

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,46 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  run-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # see https://github.com/microsoft/setup-msbuild
+      - name: Add msbuild to PATH
+        if: startsWith(matrix.os, 'windows')
+        uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          pip install numpy Cython pytest
+
+      - name: Install package
+        shell: bash
+        run: |
+          python3 setup.py install --verbose
+
+      - name: Test
+        shell: bash
+        run: |
+          pytest tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          pip install numpy Cython pytest
+          pip install numpy Cython pytest pytest-benchmark
 
       - name: Install package
         shell: bash
@@ -44,3 +44,8 @@ jobs:
         shell: bash
         run: |
           pytest tests
+
+      - name: Benchmark
+        shell: bash
+        run: |
+          pytest benchmark

--- a/benchmark/test_reverb.py
+++ b/benchmark/test_reverb.py
@@ -1,0 +1,18 @@
+import numpy as np
+from cylimiter import ReverbRIR
+
+
+def run(audio):
+    effect = ReverbRIR()
+    return effect.apply(audio)
+
+
+def test_reverb_speed(benchmark):
+    # 10s of audio in -1, 1 range as fp32
+    audio = ((np.random.rand(441000) - 0.5) * 2).astype(np.float32)
+
+    out = benchmark(run, audio)
+
+    # Check basic properties of the output
+    assert out.shape == audio.shape
+    assert (out != audio).any()

--- a/extensions/reverb_rir.cpp
+++ b/extensions/reverb_rir.cpp
@@ -70,7 +70,7 @@ void ReverbRIR::apply_inplace(float * const audio, const size_t num_samples) {
         #elif defined(__GNUC__)
         const auto sum = inner_product_gcc(buffer_, rir_, idx);
         #else
-        const auto sum = inner_product(buffer_.cbegin() + idx, buffer_.cbegin() + idx + RIR_SIZE, rir_.cbegin(), 0.0f);
+        const auto sum = inner_product(buffer_.cbegin() + idx, buffer_.cbegin() + idx + rir_.size(), rir_.cbegin(), 0.0f);
         #endif
 
         audio[idx] = mix_ * sum + dry * audio[idx];

--- a/extensions/reverb_rir.cpp
+++ b/extensions/reverb_rir.cpp
@@ -58,7 +58,6 @@ float inner_product_gcc(const vector<float> &buffer_, const vector<float> &rir_,
 }
 
 void ReverbRIR::apply_inplace(float * const audio, const size_t num_samples) {
-//    const auto RIR_SIZE = rir_.size();
     const auto dry = 1.0f - mix_;
     copy(audio, audio + num_samples, back_inserter(buffer_));
     for (unsigned int idx = 0; idx < num_samples; ++idx) {
@@ -66,7 +65,6 @@ void ReverbRIR::apply_inplace(float * const audio, const size_t num_samples) {
         // Apparently std::inner_product does not get auto-vectorized,
         // but we can help the compiler with a few pragmas, so we write
         // it out explicitly.
-
         #if defined(__clang__)
         const auto sum = inner_product_clang(buffer_, rir_, idx);
         #elif defined(__GNUC__)
@@ -74,12 +72,6 @@ void ReverbRIR::apply_inplace(float * const audio, const size_t num_samples) {
         #else
         const auto sum = inner_product(buffer_.cbegin() + idx, buffer_.cbegin() + idx + RIR_SIZE, rir_.cbegin(), 0.0f);
         #endif
-
-//        float sum = 0.0f;
-//        #pragma clang loop vectorize(assume_safety)
-//        for (unsigned int i = 0; i < RIR_SIZE; ++i) {
-//            sum += buffer_[idx + i] * rir_[i];
-//        }
 
         audio[idx] = mix_ * sum + dry * audio[idx];
     }

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ def main() -> None:
             'dev': ['pytest', 'Cython']
         },
         ext_modules=extensions,
-        packages=find_packages(exclude=["tests"]),
+        packages=find_packages(exclude=["tests", "benchmark"]),
         zip_safe=False,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     cythonize = None
 
+
 # https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules
 def no_cythonize(extensions, **_ignore):
     for extension in extensions:
@@ -28,19 +29,20 @@ def no_cythonize(extensions, **_ignore):
     return extensions
 
 
-COMPILE_ARGS = [
-    "-std=c++11",
-    "-funsigned-char",
-]
+COMPILE_ARGS = []
+
 if os.name != "nt":
-    COMPILE_ARGS.append("-Wno-register")
-    COMPILE_ARGS.append("-Wno-unused-function")
-    COMPILE_ARGS.append("-Wno-unused-local-typedefs")
+    COMPILE_ARGS.extend([
+        "-std=c++11",
+        "-funsigned-char",
+        "-Wno-register",
+        "-Wno-unused-function",
+        "-Wno-unused-local-typedefs",
+    ])
 
 if platform.startswith("darwin"):
     COMPILE_ARGS.append("-stdlib=libc++")
     COMPILE_ARGS.append("-mmacosx-version-min=10.7")
-
 
 cylimiter = Extension(
     name="cylimiter",
@@ -53,16 +55,13 @@ extensions = [cylimiter]
 
 CYTHONIZE = bool(int(os.getenv("CYTHONIZE", 0))) and cythonize is not None
 
-
 if CYTHONIZE:
     compiler_directives = {"language_level": 3, "embedsignature": True}
     extensions = cythonize(extensions, compiler_directives=compiler_directives)
 else:
     extensions = no_cythonize(extensions)
 
-
 __version__ = "0.4.2"
-
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf8") as source:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ else:
     extensions = no_cythonize(extensions)
 
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 this_directory = path.abspath(path.dirname(__file__))

--- a/tests/test_reverb_rir.py
+++ b/tests/test_reverb_rir.py
@@ -60,7 +60,6 @@ def test_reverb_inplace_fails_with_float64():
         effect.apply_inplace(audio)
 
 
-@pytest.mark.bench
 def test_reverb_inplace():
     effect = ReverbRIR()
     chunk_size = 1200  # for streaming processing


### PR DESCRIPTION
Only tested on apple clang, but I noticed another 10x speedup. It seems quite tricky to write in a platform agnostic way (without breaking down into functions, the pragma wouldn't work on clang together with ifdefs).

I should add CI on other platforms for this repo.